### PR TITLE
优化BeautifulReport

### DIFF
--- a/ui/lib/base_runner.py
+++ b/ui/lib/base_runner.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import os
+import time
 import unittest
 import warnings
 import logging
@@ -10,7 +11,7 @@ from common.lib.base_config import UI_OUTPUT_DIR
 class BaseAppTestCase(unittest.TestCase):
     driver = None
     output_dir = UI_OUTPUT_DIR
-    screenshot_dir = os.path.join(UI_OUTPUT_DIR, 'img')
+    screenshot_dir = os.path.join(UI_OUTPUT_DIR, 'img', '{}'.format(time.strftime('%Y%m%d')))
 
     @classmethod
     def setUpClass(cls):
@@ -31,15 +32,17 @@ class BaseAppTestCase(unittest.TestCase):
         pass
 
     def save_img(self, img_name):
-        img_path = os.path.join(UI_OUTPUT_DIR, 'img')
         if self.driver is not None:
-            self.driver.get_screenshot_as_file('{}/{}.png'.format(img_path, img_name))
+            img_path = os.path.join(self.screenshot_dir, '{}.png'.format(img_name))
+            if os.path.exists(img_path):
+                os.remove(img_path)
+            self.driver.get_screenshot_as_file(img_path)
 
 
 class BaseWebTestCase(unittest.TestCase):
     driver = None
     output_dir = UI_OUTPUT_DIR
-    screenshot_dir = os.path.join(UI_OUTPUT_DIR, 'img')
+    screenshot_dir = os.path.join(UI_OUTPUT_DIR, 'img', '{}'.format(time.strftime('%Y%m%d')))
 
     @classmethod
     def setUpClass(cls):
@@ -54,12 +57,14 @@ class BaseWebTestCase(unittest.TestCase):
             cls.driver.quit()
 
     def setUp(self):
-        logging.info("-----Test Start-----")        
+        logging.info("-----Test Start-----")
 
     def tearDown(self):
         logging.info("-----Test End-----")
 
     def save_img(self, img_name):
-        img_path = os.path.join(UI_OUTPUT_DIR, 'img')
         if self.driver is not None:
-            self.driver.get_screenshot_as_file('{}/{}.png'.format(img_path, img_name))
+            img_path = os.path.join(self.screenshot_dir, '{}.png'.format(img_name))
+            if os.path.exists(img_path):
+                os.remove(img_path)
+            self.driver.get_screenshot_as_file(img_path)

--- a/ui/test/test_case/app_test.py
+++ b/ui/test/test_case/app_test.py
@@ -16,7 +16,9 @@ class app_test(BaseAppTestCase):
     def setUpClass(cls):
         cls.driver = appium_desired("android_baidumap")
 
-    @BeautifulReport.add_test_img(BaseAppTestCase.output_dir, 'app_test_test_1{}'.format(time.strftime('%Y%m%d%H%M%S')))
+    # 有异常发生时会自动截图并呈现在报告中，
+    # 其他需要呈现在报告里的截图，必须手动添加截图名称。
+    @BeautifulReport.add_test_img()
     def test_1_search_location(self):
         baidumap = Demo_BaiduMap(self.driver)
 
@@ -30,7 +32,7 @@ class app_test(BaseAppTestCase):
 
 
     @unittest.skip
-    @BeautifulReport.add_test_img(BaseAppTestCase.output_dir, 'app_test_test_2{}'.format(time.strftime('%Y%m%d%H%M%S')))
+    @BeautifulReport.add_test_img()
     def test_2_get_road(self):
         pass
 

--- a/ui/test/test_case/web_test.py
+++ b/ui/test/test_case/web_test.py
@@ -17,12 +17,16 @@ class web_test(BaseWebTestCase):
         #self.data = Yaml(web_config_path).read()
         #self.env = self.data['env']
 
-    @BeautifulReport.add_test_img(BaseWebTestCase.output_dir, 'test_topbar_navigation_{}'.format(time.strftime('%Y%m%d%H%M%S')))
+    # 有异常发生时会自动截图并呈现在报告中，
+    # 其他需要呈现在报告里的截图，必须手动添加截图名称。
+    @BeautifulReport.add_test_img('web_test-test_1-screenshot1')
     def test_topbar_navigation(self):
         self._testMethodDoc = "Validate topbar navigation"
         self.driver = simple_login()
         stream_topbar_business = Stream_topbar_business(self.driver)
         # TODO: add test steps and asserts.
+        # 如果没有报错也需要截图，可以调用self.save_img() 方法
+        self.save_img('web_test-test_1-screenshot1')
         #stream_topbar_business.goto_feature_page(FeaturePage.mycontent_videos)
         #self.assertTrue(self.driver.current_url.endswith('/studio/videos'))
         #stream_topbar_business.goto_feature_page(FeaturePage.mycontent_channels)


### PR DESCRIPTION
1. 优化了BeautifulReport.add_test_img()，默认不需要填任何参数。
2. 修复了生成的html报告中呈现的问题。
3. 用例抛错退出时依然会输出之前生成的所有截图到html报告，截图按日期保存在对应目录下